### PR TITLE
Add data transformations to response and request

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,42 @@ api.show('users', { id: 1, expanded: false })
 ```
 <br>
 
-## Passing options to Axios
-As the first argument when creating a new instance of Rails Ranger, you can pass an object of options that will be handled to Axios. Some examples:
+## Options
+As the first argument when creating a new instance of Rails Ranger you can pass an object of options to customize the behavior of Rails Ranger.
 
-### Base URL
+### dataTransform
+**default: true**
+
+By default RailsRanger will convert camelCased keys in your jsons to snake_case when sending a request to Rails, and will convert the Rails response from snake_case to camelCase for you to use in your front-end.
+
+You can disable this behavior by setting `dataTransform` to false:
+
 ```javascript
-const api = new RailsRanger({ baseUrl: 'http://myapp.com/api' })
+const api = new RailsRanger({ dataTransform: false })
+```
+
+### axios
+**default: {}**
+
+Any object passed to the `axios` option will be handled to **Axios**.
+Here are some usage examples:
+
+#### Base URL
+```javascript
+const api = new RailsRanger({ axios: { baseUrl: 'http://myapp.com/api' } })
 
 api.list('users')
 // => GET request to http://myapp.com/api/users
 ```
 
-### Timeout
+#### Timeout
 ```javascript
-const api = new RailsRanger({ timeout: 3000 })
+const api = new RailsRanger({ axios: { timeout: 3000 } })
 
 api.list('users') // => Will timeout within 3000 miliseconds
 ```
 
-### See more in the [Axios documentation](https://github.com/mzabriskie/axios#request-config)
+#### See more in the [Axios documentation](https://github.com/mzabriskie/axios#request-config)
 <br>
 
 ## Using Rails Ranger just for building routes
@@ -76,7 +93,7 @@ const route = new RouteBuilder
 
 route.create('users', { name: 'John' })
 // => { path: '/users', params: { name: 'John' }, method: 'post' }
- 
+
 route.show('users', { id: 1, hidePassword: true })
 // => { path: '/users/1?hide_password=true', params: {}, method: 'get' }
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
+    "humps": "^2.0.1",
     "lodash": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Ruby on Rails REST client",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test nyc mocha test/unit --require test/setup.js",
+    "test": "NODE_ENV=test nyc mocha test/unit --recursive --require test/setup.js",
     "generate-docs": "jsdoc --configure .jsdoc-conf.json --verbose",
     "build": "webpack"
   },

--- a/src/rails-ranger.js
+++ b/src/rails-ranger.js
@@ -9,15 +9,24 @@ class RailsRanger {
   * @constructor
   * @param {object} configs - Configurations to be handed to Axios.
   */
-  constructor (userConfigs = {}) {
-    const baseConfigs = {
-      transformRequest:  [DataTransformations.prepareRequest],
-      transformResponse: [DataTransformations.prepareResponse]
+  constructor (configs = { transformData: true, axios: {} }) {
+    this.options = {
+      transformData: configs.transformData
     }
 
-    const configs = Object.assign({}, baseConfigs, userConfigs)
+    const baseClientConfigs = {}
 
-    this.client       = Axios.create(configs)
+    if (this.options.transformData) {
+      const dataTransformations = {
+        transformRequest:  [DataTransformations.prepareRequest],
+        transformResponse: [DataTransformations.prepareResponse]
+      }
+      Object.assign(baseClientConfigs, dataTransformations)
+    }
+
+    const clientConfigs = Object.assign({}, baseClientConfigs, configs.axios)
+
+    this.client       = Axios.create(clientConfigs)
     this.routeBuilder = new RouteBuilder()
     this.pathBuilder  = new PathBuilder()
   }

--- a/src/rails-ranger.js
+++ b/src/rails-ranger.js
@@ -1,6 +1,7 @@
-import Axios        from 'axios'
-import PathBuilder  from './path-builder'
-import RouteBuilder from './rails-route-builder'
+import Axios               from 'axios'
+import PathBuilder         from './path-builder'
+import RouteBuilder        from './rails-route-builder'
+import DataTransformations from './utils/data-transformations'
 
 class RailsRanger {
   /**
@@ -8,7 +9,14 @@ class RailsRanger {
   * @constructor
   * @param {object} configs - Configurations to be handed to Axios.
   */
-  constructor (configs = {}) {
+  constructor (userConfigs = {}) {
+    const baseConfigs = {
+      transformRequest:  [DataTransformations.prepareRequest],
+      transformResponse: [DataTransformations.prepareResponse]
+    }
+
+    const configs = Object.assign({}, baseConfigs, userConfigs)
+
     this.client       = Axios.create(configs)
     this.routeBuilder = new RouteBuilder()
     this.pathBuilder  = new PathBuilder()

--- a/src/utils/data-transformations.js
+++ b/src/utils/data-transformations.js
@@ -1,0 +1,24 @@
+import { camelizeKeys, decamelizeKeys } from 'humps'
+
+const DataTransformations = {
+  prepareRequest (data, headers) {
+    if (headers && headers['Content-Type'] === undefined) {
+      headers['Content-Type'] = 'application/json;charset=utf-8'
+    }
+    return JSON.stringify(this.railsFormat(data))
+  },
+
+  prepareResponse (data, _headers) {
+    return this.jsFormat(data)
+  },
+
+  railsFormat (data) {
+    return decamelizeKeys(data)
+  },
+
+  jsFormat (data) {
+    return camelizeKeys(data)
+  }
+}
+
+export default DataTransformations

--- a/src/utils/data-transformations.js
+++ b/src/utils/data-transformations.js
@@ -1,11 +1,12 @@
 import { camelizeKeys, decamelizeKeys } from 'humps'
+import Axios                            from 'axios'
 
 const DataTransformations = {
   prepareRequest (data, headers) {
-    if (headers && headers['Content-Type'] === undefined) {
-      headers['Content-Type'] = 'application/json;charset=utf-8'
-    }
-    return JSON.stringify(this.railsFormat(data))
+    const defaultTransformRequest = Axios.defaults.transformRequest[0]
+    const railsData               = this.railsFormat(data)
+
+    return defaultTransformRequest(railsData, headers)
   },
 
   prepareResponse (data, _headers) {

--- a/test/unit/rails-ranger.js
+++ b/test/unit/rails-ranger.js
@@ -20,6 +20,18 @@ describe('RailsRanger', () => {
       let railsRanger = new RailsRanger()
       expect(railsRanger.routeBuilder).to.be.an('object')
     })
+
+    describe('transformData', () => {
+      it('sets the options.transformData to the correct default when no argument is provided', () => {
+        let railsRanger = new RailsRanger()
+        expect(railsRanger.options.transformData).to.eq(true)
+      })
+
+      it('sets the options.transformData when provided the correct argument', () => {
+        let railsRanger = new RailsRanger({ transformData: false })
+        expect(railsRanger.options.transformData).to.eq(false)
+      })
+    })
   })
 
   describe('.get', () => {

--- a/test/unit/utils/data-transformations.js
+++ b/test/unit/utils/data-transformations.js
@@ -1,0 +1,84 @@
+import DataTransformations from '../../../src/utils/data-transformations'
+
+describe('DataTransformations', () => {
+  describe('.prepareRequest', () => {
+    it('sets the content-type to JSON if there is none set', () => {
+      const data    = { name: 'John' }
+      const headers = {}
+
+      DataTransformations.prepareRequest(data, headers)
+
+      expect(headers).to.deep.eq({ 'Content-Type': 'application/json;charset=utf-8' })
+    })
+
+    it('preserves the content-type if there is one already', () => {
+      const data    = { name: 'John' }
+      const headers = { 'Content-Type': 'foo' }
+
+      DataTransformations.prepareRequest(data, headers)
+
+      expect(headers).to.deep.eq({ 'Content-Type': 'foo' })
+    })
+
+    it('formats the data in Ruby on Rails format', () => {
+      const data    = { name: 'John' }
+      const headers = {}
+
+      spy(DataTransformations, 'railsFormat')
+
+      DataTransformations.prepareRequest(data, headers)
+
+      expect(DataTransformations.railsFormat).to.have.been.calledWith(data)
+    })
+
+    it('returns the data as string', () => {
+      const data    = { name: 'John' }
+      const headers = {}
+
+      const result = DataTransformations.prepareRequest(data, headers)
+
+      expect(result).to.eq('{"name":"John"}')
+    })
+  })
+
+  describe('.prepareResponse', () => {
+    it('formats the data in Javascript format', () => {
+      const data    = { name: 'John' }
+      const headers = {}
+
+      spy(DataTransformations, 'jsFormat')
+
+      DataTransformations.prepareResponse(data, headers)
+
+      expect(DataTransformations.jsFormat).to.have.been.calledWith(data)
+    })
+  })
+
+  describe('.railsFormat', () => {
+    it('returns the given data with snake_cased keys', () => {
+      const data = {
+        name:        'John',
+        last_name:   'Doe',
+        homeAddress: 'none'
+      }
+
+      const result = DataTransformations.railsFormat(data)
+
+      expect(result).to.deep.eq({ name: 'John', last_name: 'Doe', home_address: 'none' })
+    })
+  })
+
+  describe('.jsFormat', () => {
+    it('returns the given data with camelCased keys', () => {
+      const data = {
+        name:        'John',
+        last_name:   'Doe',
+        homeAddress: 'none'
+      }
+
+      const result = DataTransformations.jsFormat(data)
+
+      expect(result).to.deep.eq({ name: 'John', lastName: 'Doe', homeAddress: 'none' })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1401,6 +1401,10 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"


### PR DESCRIPTION
# Description

This PR implements automatic camelCase/snake_case conversion between requests and responses made with Rails Ranger.

**For response:**
- JSON data received will have it's keys transformed into camelCase
  (prefered format for Javascript)

**For request:**
- JSON data sent will have it's keys transformed into snake_case
  (prefered format for Ruby on Rails)

### To-do:
- [x] JSON keys transformation
- [x] Test if other request formats (non-JSON) may have problems with the data transformation
- [x] Add option to turn off the transformation functions.
- [x] Add documentation

Closes #9 