### PR TITLE
Allow the usage of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ api.resource('users', 1).list('blogPosts')
 ```
 <br>
 
+## Namespaced routes
+The `.namespace` function can help you to build a path nested within a Rails namespace:
+
+```javascript
+api.namespace('users').list('blogPosts')
+//=> GET request to /users/blog_posts
+
+
+api.namespace('admin_roles/:type', { type: 1 }).list('blogPosts')
+//=> GET request to /admin_roles/1/blog_posts
+```
+<br>
+
 ## Available actions
 
 ### List/Index

--- a/src/rails-ranger.js
+++ b/src/rails-ranger.js
@@ -44,12 +44,24 @@ class RailsRanger {
   * //=> GET request to '/users/1/blog_posts' path
   */
   resource (resource, id = null) {
-    const newInstance     = clone(this)
     const newRouteBuilder = this.routeBuilder.resource(resource, id)
 
-    newInstance.routeBuilder = newRouteBuilder
+    return this._newInstanceWithNewRouteBuilder(newRouteBuilder)
+  }
 
-    return newInstance
+  /**
+  * Defines a namespace to be used in the next request of the chain
+  * @param {string} namespace - The path fragment to be used as the namespace
+  * @param {object} params - The parameters to be interpolated into the path, can be left empty
+  * @example
+  * const api = new RailsRanger
+  * api.namespace('admin/:type', { type: 'super' }).list('blogPosts')
+  * //=> GET request to '/admin/super/blog_posts' path
+  */
+  namespace (namespace, params = {}) {
+    const newRouteBuilder = this.routeBuilder.namespace(namespace, params)
+
+    return this._newInstanceWithNewRouteBuilder(newRouteBuilder)
   }
 
   /**
@@ -237,6 +249,12 @@ class RailsRanger {
     const request = this.routeBuilder[action](resource, params)
 
     return this.client[request.method](request.path, request.params)
+  }
+
+  _newInstanceWithNewRouteBuilder (newRouteBuilder) {
+    const newInstance        = clone(this)
+    newInstance.routeBuilder = newRouteBuilder
+    return newInstance
   }
 }
 

--- a/src/rails-route-builder.js
+++ b/src/rails-route-builder.js
@@ -22,14 +22,37 @@ class RailsRouteBuilder {
   * //=> { path: '/users/1/blog_posts', params: {} }
   */
   resource (resource, id = null) {
+    const snakedResource = snakeCase(resource)
+
+    if (id) {
+      return this.namespace(`${snakedResource}/:id`, { id })
+    } else {
+      return this.namespace(snakedResource)
+    }
+  }
+
+  /**
+  * Defines a namespace to be used in the next route of the chain
+  * @param {string} namespace - The path fragment to be used as the namespace
+  * @param {object} params - The parameters to be interpolated into the path, can be left empty
+  * @example
+  * const routes = new RailsRouteBuilder
+  * routes.namespace('admin').list('blogPosts')
+  * //=> { path: '/admin/blog_posts', params: {} }
+  */
+  namespace (namespace, params = {}) {
     const newInstance = clone(this)
-    const path        = id ? `${snakeCase(resource)}/${id}` : resource
 
     // Duplicates the chainedPaths as a new object
     newInstance.chainedPaths = clone(this.chainedPaths)
 
+    // Process the given namespace interpolating params on the path
+    // Ex:
+    // 'users/:id' with params { id: 1 } becomes 'users/1'
+    const pathAndParams = this.pathBuilder._paramsToPath({ path: namespace, params })
+
     // Pushes the new namespace to the chainedPaths
-    newInstance.chainedPaths.push(path)
+    newInstance.chainedPaths.push(pathAndParams['path'])
 
     return newInstance
   }

--- a/test/unit/rails-ranger.js
+++ b/test/unit/rails-ranger.js
@@ -227,6 +227,11 @@ describe('RailsRanger', () => {
       ranger.resource('projects', 1).destroy('users', { id: 2 })
       expect(ranger.client.delete).to.have.been.calledWith('projects/1/users/2')
     })
+
+    it('works with a namespace', () => {
+      ranger.namespace('blog_posts').destroy('users', { id: 2 })
+      expect(ranger.client.delete).to.have.been.calledWith('blog_posts/users/2')
+    })
   })
 
   describe('.new', () => {
@@ -249,6 +254,11 @@ describe('RailsRanger', () => {
       ranger.resource('projects', 1).new('users')
       expect(ranger.client.get).to.have.been.calledWith('projects/1/users/new')
     })
+
+    it('works with a namespace', () => {
+      ranger.namespace('blog_posts/:id', { id: 1 }).new('users')
+      expect(ranger.client.get).to.have.been.calledWith('blog_posts/1/users/new')
+    })
   })
 
   describe('.edit', () => {
@@ -270,6 +280,11 @@ describe('RailsRanger', () => {
     it('works with a resource namespace', () => {
       ranger.resource('projects', 1).edit('users', { id: 2 })
       expect(ranger.client.get).to.have.been.calledWith('projects/1/users/2/edit')
+    })
+
+    it('works with a namespace', () => {
+      ranger.namespace('blog_posts/:id', { id: 1 }).edit('users', { id: 2 })
+      expect(ranger.client.get).to.have.been.calledWith('blog_posts/1/users/2/edit')
     })
   })
 

--- a/test/unit/rails-route-builder.js
+++ b/test/unit/rails-route-builder.js
@@ -201,7 +201,7 @@ describe('RailsRouteBuilder', () => {
 
         it('pushes the right data into the chainedPaths list', () => {
           let newInstance = routeBuilder.resource('users').resource('blogPosts')
-          expect(newInstance.chainedPaths).to.have.same.members(['users', 'blogPosts'])
+          expect(newInstance.chainedPaths).to.have.same.members(['users', 'blog_posts'])
         })
       })
     })
@@ -227,6 +227,65 @@ describe('RailsRouteBuilder', () => {
 
         it('pushes the right data into the chainedPaths list', () => {
           let newInstance = routeBuilder.resource('users', 1).resource('blogPosts', 2)
+          expect(newInstance.chainedPaths).to.have.same.members(['users/1', 'blog_posts/2'])
+        })
+      })
+    })
+  })
+
+  describe('.namespace', () => {
+    it('does not taint the original instance', () => {
+      routeBuilder.namespace('users')
+      expect(routeBuilder.chainedPaths).to.be.empty
+    })
+
+    context('namespace without params', () => {
+      context('single call to .namespace', () => {
+        it('returns a new RailsRouteBuilder instance', () => {
+          let returnedValue = routeBuilder.namespace('users')
+          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+        })
+
+        it('pushes the right data into the chainedPaths attribute', () => {
+          let newInstance = routeBuilder.namespace('users')
+          expect(newInstance.chainedPaths).to.have.same.members(['users'])
+        })
+      })
+
+      context('chained calls to .namespace', () => {
+        it('returns a new RailsRouteBuilder instance', () => {
+          let returnedValue = routeBuilder.namespace('users').namespace('blog_post')
+          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+        })
+
+        it('pushes the right data into the chainedPaths list', () => {
+          let newInstance = routeBuilder.namespace('users').namespace('blog_posts')
+          expect(newInstance.chainedPaths).to.have.same.members(['users', 'blog_posts'])
+        })
+      })
+    })
+
+    context('namespace with params', () => {
+      context('single call to .namespace', () => {
+        it('returns a new RailsRouteBuilder instance', () => {
+          let returnedValue = routeBuilder.namespace('users/:id', { id: 1 })
+          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+        })
+
+        it('pushes the right data into the chainedPaths attribute', () => {
+          let newInstance = routeBuilder.namespace('users/:id', { id: 1 })
+          expect(newInstance.chainedPaths).to.have.same.members(['users/1'])
+        })
+      })
+
+      context('chained calls to .namespace', () => {
+        it('returns a new RailsRouteBuilder instance', () => {
+          let returnedValue = routeBuilder.namespace('users/:id', { id: 1 }).namespace('blog_post/:id', { id: 2 })
+          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+        })
+
+        it('pushes the right data into the chainedPaths list', () => {
+          let newInstance = routeBuilder.namespace('users/:id', { id: 1 }).namespace('blog_posts/:id', { id: 2 })
           expect(newInstance.chainedPaths).to.have.same.members(['users/1', 'blog_posts/2'])
         })
       })


### PR DESCRIPTION
This PR introduces a namespace feature that works like this:

```javascript
api.namespace('admin').list('users')
// => admin/users

api.namespace('blog_posts/:id', { id: 1 }).list('users')
// => blogs/1/users
```

The `resource` feature now works on top of the `namespace` function, so this:

```javascript
api.resource('blogPosts', 1)
```

Is the same as this:
```javascript
api.namespace('blog_posts/:id', { id: 1 })
```
### Pending
- [ ] Documentation on README

Closes #1 