### PR TITLE
Fix multiple parameters injection on URL

### DIFF
--- a/src/path-builder.js
+++ b/src/path-builder.js
@@ -56,7 +56,8 @@ class PathBuilder {
       if (!path.includes(symbol)) { continue }
 
       // Replaces the symbol in the path with the param value
-      processedPath = processedPath.replace(symbol, params[key])
+      const symbolRegex = new RegExp(symbol, 'g')
+      processedPath = processedPath.replace(symbolRegex, params[key])
 
       // If the key was used in the path, it shouldn't be sent asa query parameter
       delete processedParams[key]

--- a/src/path-builder.js
+++ b/src/path-builder.js
@@ -56,7 +56,7 @@ class PathBuilder {
       if (!path.includes(symbol)) { continue }
 
       // Replaces the symbol in the path with the param value
-      processedPath = path.replace(symbol, params[key])
+      processedPath = processedPath.replace(symbol, params[key])
 
       // If the key was used in the path, it shouldn't be sent asa query parameter
       delete processedParams[key]

--- a/test/unit/path-builder.js
+++ b/test/unit/path-builder.js
@@ -18,6 +18,11 @@ describe('PathBuilder', () => {
       expect(request.path).to.eq('/users/admin/1')
     })
 
+    it('interpolates multiple instances of the same parameter into the path', () => {
+      let request = pathBuilder.get('/users/:id/:id', { id: 1 })
+      expect(request.path).to.eq('/users/1/1')
+    })
+
     it('interpolates parameters into the query', () => {
       let request = pathBuilder.get('/users/', { id: 1 })
       expect(request.path).to.eq('/users/?id=1')

--- a/test/unit/path-builder.js
+++ b/test/unit/path-builder.js
@@ -13,6 +13,11 @@ describe('PathBuilder', () => {
       expect(request.path).to.eq('/users/1')
     })
 
+    it('interpolates more than one parameter into the path', () => {
+      let request = pathBuilder.get('/users/:role/:id', { role: 'admin', id: 1 })
+      expect(request.path).to.eq('/users/admin/1')
+    })
+
     it('interpolates parameters into the query', () => {
       let request = pathBuilder.get('/users/', { id: 1 })
       expect(request.path).to.eq('/users/?id=1')


### PR DESCRIPTION
# Description
Reported on issue #26 

```js
api.get('/some_path/:foo/:bar', { foo: 1, bar: 2 })

// Expected result
// => Request to /some_path/1/2

// Result before the fix
// => Request to /some_path/:foo/2
```

This PR fixes the current behavior to comply with the expected result 😄 