### PR TITLE
Move raw requests (GET, POST, etc) to RouteBuilder

### DIFF
--- a/src/rails-ranger.js
+++ b/src/rails-ranger.js
@@ -1,7 +1,6 @@
 import Axios               from 'axios'
 import { clone }           from 'lodash'
-import PathBuilder         from './path-builder'
-import RouteBuilder        from './rails-route-builder'
+import RouteBuilder        from './route-builder'
 import DataTransformations from './utils/data-transformations'
 
 class RailsRanger {
@@ -31,7 +30,6 @@ class RailsRanger {
 
     this.client       = Axios.create(clientConfigs)
     this.routeBuilder = new RouteBuilder()
-    this.pathBuilder  = new PathBuilder()
   }
 
   /**
@@ -75,7 +73,7 @@ class RailsRanger {
   * //=> GET request to '/users/1?flag=true' path
   */
   get (path, params) {
-    return this._rawRequest({ method: 'get', path, params })
+    return this._performRawRequest({ method: 'get', path, params })
   }
 
   /**
@@ -89,7 +87,7 @@ class RailsRanger {
   * //=> POST request to '/users/1' path with { flag: true } parameters
   */
   post (path, params) {
-    return this._rawRequest({ method: 'post', path, params })
+    return this._performRawRequest({ method: 'post', path, params })
   }
 
   /**
@@ -103,7 +101,7 @@ class RailsRanger {
   * //=> PATCH request to '/users/1' path with { flag: true } parameters
   */
   patch (path, params) {
-    return this._rawRequest({ method: 'patch', path, params })
+    return this._performRawRequest({ method: 'patch', path, params })
   }
 
   /**
@@ -117,7 +115,7 @@ class RailsRanger {
   * //=> PUT request to '/users/1' path with { flag: true } parameters
   */
   put (path, params) {
-    return this._rawRequest({ method: 'put', path, params })
+    return this._performRawRequest({ method: 'put', path, params })
   }
 
   /**
@@ -131,7 +129,7 @@ class RailsRanger {
   * //=> DELETE request to '/users/1?flag=true' path
   */
   delete (path, params) {
-    return this._rawRequest({ method: 'delete', path, params })
+    return this._performRawRequest({ method: 'delete', path, params })
   }
 
   /**
@@ -145,7 +143,7 @@ class RailsRanger {
   * //=> GET request to '/users?flag=true' path
   */
   list (resource, params) {
-    return this._actionRequest({ action: 'index', resource, params })
+    return this._performActionRequest({ action: 'index', resource, params })
   }
 
   /**
@@ -160,7 +158,7 @@ class RailsRanger {
   * //=> GET request to '/users/1?flag=true' path
   */
   show (resource, params) {
-    return this._actionRequest({ action: 'show', resource, params })
+    return this._performActionRequest({ action: 'show', resource, params })
   }
 
   /**
@@ -175,7 +173,7 @@ class RailsRanger {
   * //=> DELETE request to '/users/1?flag=true' path
   */
   destroy (resource, params) {
-    return this._actionRequest({ action: 'destroy', resource, params })
+    return this._performActionRequest({ action: 'destroy', resource, params })
   }
 
   /**
@@ -189,7 +187,7 @@ class RailsRanger {
   * //=> POST request to '/users' path with the { email: 'john@doe.com', password: 123456 } parameters
   */
   create (resource, params) {
-    return this._actionRequest({ action: 'create', resource, params })
+    return this._performActionRequest({ action: 'create', resource, params })
   }
 
   /**
@@ -204,7 +202,7 @@ class RailsRanger {
   * //=> PATCH request to '/users/1' path with the { email: 'elton@doe.com' } parameters
   */
   update (resource, params) {
-    return this._actionRequest({ action: 'update', resource, params })
+    return this._performActionRequest({ action: 'update', resource, params })
   }
 
   /**
@@ -218,7 +216,7 @@ class RailsRanger {
   * //=> GET request to '/users/new?flag=true' path
   */
   new (resource, params) {
-    return this._actionRequest({ action: 'new', resource, params })
+    return this._performActionRequest({ action: 'new', resource, params })
   }
 
   /**
@@ -233,19 +231,19 @@ class RailsRanger {
   * //=> GET request to '/users/1/edit?flag=true' path
   */
   edit (resource, params) {
-    return this._actionRequest({ action: 'edit', resource, params })
+    return this._performActionRequest({ action: 'edit', resource, params })
   }
 
   /**
    * Private functions
    */
-  _rawRequest ({ method, path, params }) {
-    const request = this.pathBuilder[method](path, params)
+  _performRawRequest ({ method, path, params }) {
+    const request = this.routeBuilder[method](path, params)
 
     return this.client[method](request.path, request.params)
   }
 
-  _actionRequest ({ action, resource, params }) {
+  _performActionRequest ({ action, resource, params }) {
     const request = this.routeBuilder[action](resource, params)
 
     return this.client[request.method](request.path, request.params)

--- a/src/route-builder.js
+++ b/src/route-builder.js
@@ -2,7 +2,7 @@ import { snakeCase, clone }              from 'lodash'
 import PathBuilder                       from './path-builder'
 import { MissingRequiredParameterError } from './exceptions'
 
-class RailsRouteBuilder {
+class RouteBuilder {
   /**
   * RailsRanger object constructor
   * @constructor
@@ -17,7 +17,7 @@ class RailsRouteBuilder {
   * @param {string} resource - the name of the resource to be used as namespace
   * @param {integer} id - the ID of the resource, can be left empty
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.resource('users', 1).list('blogPosts')
   * //=> { path: '/users/1/blog_posts', params: {} }
   */
@@ -36,7 +36,7 @@ class RailsRouteBuilder {
   * @param {string} namespace - The path fragment to be used as the namespace
   * @param {object} params - The parameters to be interpolated into the path, can be left empty
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.namespace('admin').list('blogPosts')
   * //=> { path: '/admin/blog_posts', params: {} }
   */
@@ -63,7 +63,7 @@ class RailsRouteBuilder {
   * @param {object} params - Any parameters for the request
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.index('users')
   * //=> { path: '/users', params: {} }
   */
@@ -73,7 +73,7 @@ class RailsRouteBuilder {
   }
 
   /**
-  * An alias for the {@link RailsRouteBuilder#index} function
+  * An alias for the {@link RouteBuilder#index} function
   */
   list (...args) {
     return this.index(...args)
@@ -86,7 +86,7 @@ class RailsRouteBuilder {
   * @param {number|string} params.id - The id of the resource
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.show('users', { id: 1 })
   * //=> { path: '/users/1', params: {} }
   */
@@ -104,7 +104,7 @@ class RailsRouteBuilder {
   * @param {number|string} params.id - The id of the resource
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.destroy('users', { id: 1 })
   * //=> { path: '/users/1', params: {} }
   */
@@ -121,7 +121,7 @@ class RailsRouteBuilder {
   * @param {object} params - Any parameters for the request
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.create('users', { email: 'john@doe.com' })
   * //=> { path: '/users', params: { email: 'john@doe.com' } }
   */
@@ -137,7 +137,7 @@ class RailsRouteBuilder {
   * @param {number|string} params.id - The id of the resource
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.update('users', { id: 1, email: 'john@doe.com' })
   * //=> { path: '/users/1', params: { email: 'john@doe.com' } }
   */
@@ -154,7 +154,7 @@ class RailsRouteBuilder {
   * @param {object} params - Any parameters for the request
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.new('users')
   * //=> { path: '/users', params: {} }
   */
@@ -170,7 +170,7 @@ class RailsRouteBuilder {
   * @param {number|string} params.id - The id of the resource
   * @returns {Promise}
   * @example
-  * const routes = new RailsRouteBuilder
+  * const routes = new RouteBuilder
   * routes.edit('users', { id: 1 })
   * //=> { path: '/users/1', params: {} }
   */
@@ -179,6 +179,81 @@ class RailsRouteBuilder {
 
     const path = `${snakeCase(resource)}/:id/edit`
     return this._buildPath('get', path, params)
+  }
+
+  /**
+  * Returns a path and params to the specified GET request
+  * @param {string} path - A path for the request
+  * @param {object} params - Any parameters for the request
+  * @param {number|string} params.id - The id of the resource
+  * @returns {Promise}
+  * @example
+  * const routes = new RouteBuilder
+  * routes.get('users')
+  * //=> { path: '/users', params: {} }
+  */
+  get (path, params) {
+    return this._buildPath('get', path, params)
+  }
+
+  /**
+  * Returns a path and params to the specified POST request
+  * @param {string} path - A path for the request
+  * @param {object} params - Any parameters for the request
+  * @param {number|string} params.id - The id of the resource
+  * @returns {Promise}
+  * @example
+  * const routes = new RouteBuilder
+  * routes.post('users', { id: 1 })
+  * //=> { path: '/users', params: { id: 1 } }
+  */
+  post (path, params) {
+    return this._buildPath('post', path, params)
+  }
+
+  /**
+  * Returns a path and params to the specified PATCH request
+  * @param {string} path - A path for the request
+  * @param {object} params - Any parameters for the request
+  * @param {number|string} params.id - The id of the resource
+  * @returns {Promise}
+  * @example
+  * const routes = new RouteBuilder
+  * routes.patch('users', { id: 1 })
+  * //=> { path: '/users', params: { id: 1 } }
+  */
+  patch (path, params) {
+    return this._buildPath('patch', path, params)
+  }
+
+  /**
+  * Returns a path and params to the specified PUT request
+  * @param {string} path - A path for the request
+  * @param {object} params - Any parameters for the request
+  * @param {number|string} params.id - The id of the resource
+  * @returns {Promise}
+  * @example
+  * const routes = new RouteBuilder
+  * routes.put('users', { id: 1 })
+  * //=> { path: '/users', params: { id: 1 } }
+  */
+  put (path, params) {
+    return this._buildPath('put', path, params)
+  }
+
+  /**
+  * Returns a path and params to the specified DELETE request
+  * @param {string} path - A path for the request
+  * @param {object} params - Any parameters for the request
+  * @param {number|string} params.id - The id of the resource
+  * @returns {Promise}
+  * @example
+  * const routes = new RouteBuilder
+  * routes.delete('users', { id: 1 })
+  * //=> { path: '/users?id=1', params: {} }
+  */
+  delete (path, params) {
+    return this._buildPath('delete', path, params)
   }
 
   /**
@@ -197,16 +272,12 @@ class RailsRouteBuilder {
   }
 
   _mergeChainPaths (mainPath) {
-    const paths = this.chainedPaths
+    if (this.chainedPaths === []) { return mainPath }
 
-    if (paths === []) {
-      return mainPath
-    }
+    const chainPath = this.chainedPaths.reduce((mergedPath, path) => mergedPath + path + '/', '')
 
-    const chainPaths = paths.reduce((mergedPath, path) => mergedPath + path + '/', '')
-
-    return chainPaths + mainPath
+    return chainPath + mainPath
   }
 }
 
-export default RailsRouteBuilder
+export default RouteBuilder

--- a/test/unit/rails-ranger.js
+++ b/test/unit/rails-ranger.js
@@ -11,11 +11,6 @@ describe('RailsRanger', () => {
   })
 
   describe('constructor', () => {
-    it('instantiates RailsRanger with a pathBuilder', () => {
-      const railsRanger = new RailsRanger()
-      expect(railsRanger.pathBuilder).to.be.an('object')
-    })
-
     it('instantiates RailsRanger with a routeBuilder', () => {
       const railsRanger = new RailsRanger()
       expect(railsRanger.routeBuilder).to.be.an('object')
@@ -37,12 +32,12 @@ describe('RailsRanger', () => {
   describe('.get', () => {
     beforeEach(() => {
       spy(ranger.client, 'get')
-      spy(ranger.pathBuilder, 'get')
+      spy(ranger.routeBuilder, 'get')
     })
 
-    it('calls the pathBuilder', () => {
+    it('calls the routeBuilder', () => {
       ranger.get('/users/:id', { id: 1 })
-      expect(ranger.pathBuilder.get).to.have.been.calledWith('/users/:id', { id: 1 })
+      expect(ranger.routeBuilder.get).to.have.been.calledWith('/users/:id', { id: 1 })
     })
 
     it('calls the client with the right parameters', () => {
@@ -54,12 +49,12 @@ describe('RailsRanger', () => {
   describe('.post', () => {
     beforeEach(() => {
       spy(ranger.client, 'post')
-      spy(ranger.pathBuilder, 'post')
+      spy(ranger.routeBuilder, 'post')
     })
 
-    it('calls the pathBuilder', () => {
+    it('calls the routeBuilder', () => {
       ranger.post('/users/:id', { id: 1 })
-      expect(ranger.pathBuilder.post).to.have.been.calledWith('/users/:id', { id: 1 })
+      expect(ranger.routeBuilder.post).to.have.been.calledWith('/users/:id', { id: 1 })
     })
 
     it('calls the client with the right parameters', () => {
@@ -71,12 +66,12 @@ describe('RailsRanger', () => {
   describe('.put', () => {
     beforeEach(() => {
       spy(ranger.client, 'put')
-      spy(ranger.pathBuilder, 'put')
+      spy(ranger.routeBuilder, 'put')
     })
 
-    it('calls the pathBuilder', () => {
+    it('calls the routeBuilder', () => {
       ranger.put('/users/:id', { id: 1 })
-      expect(ranger.pathBuilder.put).to.have.been.calledWith('/users/:id', { id: 1 })
+      expect(ranger.routeBuilder.put).to.have.been.calledWith('/users/:id', { id: 1 })
     })
 
     it('calls the client with the right parameters', () => {
@@ -88,12 +83,12 @@ describe('RailsRanger', () => {
   describe('.patch', () => {
     beforeEach(() => {
       spy(ranger.client, 'patch')
-      spy(ranger.pathBuilder, 'patch')
+      spy(ranger.routeBuilder, 'patch')
     })
 
-    it('calls the pathBuilder', () => {
+    it('calls the routeBuilder', () => {
       ranger.patch('/users/:id', { id: 1 })
-      expect(ranger.pathBuilder.patch).to.have.been.calledWith('/users/:id', { id: 1 })
+      expect(ranger.routeBuilder.patch).to.have.been.calledWith('/users/:id', { id: 1 })
     })
 
     it('calls the client with the right parameters', () => {
@@ -105,12 +100,12 @@ describe('RailsRanger', () => {
   describe('.delete', () => {
     beforeEach(() => {
       spy(ranger.client, 'delete')
-      spy(ranger.pathBuilder, 'delete')
+      spy(ranger.routeBuilder, 'delete')
     })
 
-    it('calls the pathBuilder', () => {
+    it('calls the routeBuilder', () => {
       ranger.delete('/users/:id', { id: 1 })
-      expect(ranger.pathBuilder.delete).to.have.been.calledWith('/users/:id', { id: 1 })
+      expect(ranger.routeBuilder.delete).to.have.been.calledWith('/users/:id', { id: 1 })
     })
 
     it('calls the client with the right parameters', () => {

--- a/test/unit/route-builder.js
+++ b/test/unit/route-builder.js
@@ -1,11 +1,11 @@
-import RailsRouteBuilder from '../../src/rails-route-builder'
+import RouteBuilder from '../../src/route-builder'
 import { MissingRequiredParameterError } from '../../src/exceptions'
 
-describe('RailsRouteBuilder', () => {
+describe('RouteBuilder', () => {
   let routeBuilder = null
 
   beforeEach(() => {
-    routeBuilder = new RailsRouteBuilder()
+    routeBuilder = new RouteBuilder()
   })
 
   describe('.list', () => {
@@ -174,6 +174,76 @@ describe('RailsRouteBuilder', () => {
     })
   })
 
+  describe('.get', () => {
+    it('returns the right path and params', () => {
+      let request = routeBuilder.get('users', { flag: true })
+
+      expect(request.path).to.eq('users?flag=true')
+      expect(request.params).to.be.empty
+    })
+
+    it('returns the right method', () => {
+      let request = routeBuilder.get('users', { flag: true })
+      expect(request.method).to.eq('get')
+    })
+  })
+
+  describe('.post', () => {
+    it('returns the right path and params', () => {
+      let request = routeBuilder.post('users', { flag: true })
+
+      expect(request.path).to.eq('users')
+      expect(request.params).to.eql({ flag: true })
+    })
+
+    it('returns the right method', () => {
+      let request = routeBuilder.post('users', { flag: true })
+      expect(request.method).to.eq('post')
+    })
+  })
+
+  describe('.patch', () => {
+    it('returns the right path and params', () => {
+      let request = routeBuilder.patch('users', { flag: true })
+
+      expect(request.path).to.eq('users')
+      expect(request.params).to.eql({ flag: true })
+    })
+
+    it('returns the right method', () => {
+      let request = routeBuilder.patch('users', { flag: true })
+      expect(request.method).to.eq('patch')
+    })
+  })
+
+  describe('.put', () => {
+    it('returns the right path and params', () => {
+      let request = routeBuilder.put('users', { flag: true })
+
+      expect(request.path).to.eq('users')
+      expect(request.params).to.eql({ flag: true })
+    })
+
+    it('returns the right method', () => {
+      let request = routeBuilder.put('users', { flag: true })
+      expect(request.method).to.eq('put')
+    })
+  })
+
+  describe('.delete', () => {
+    it('returns the right path and params', () => {
+      let request = routeBuilder.delete('users', { flag: true })
+
+      expect(request.path).to.eq('users?flag=true')
+      expect(request.params).to.be.empty
+    })
+
+    it('returns the right method', () => {
+      let request = routeBuilder.delete('users', { flag: true })
+      expect(request.method).to.eq('delete')
+    })
+  })
+
   describe('.resource', () => {
     it('does not taint the original instance', () => {
       routeBuilder.resource('users')
@@ -182,9 +252,9 @@ describe('RailsRouteBuilder', () => {
 
     context('resource without id', () => {
       context('single call to .resource', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.resource('users')
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths attribute', () => {
@@ -194,9 +264,9 @@ describe('RailsRouteBuilder', () => {
       })
 
       context('chained calls to .resource', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.resource('users').resource('blogPost')
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths list', () => {
@@ -208,9 +278,9 @@ describe('RailsRouteBuilder', () => {
 
     context('resource with id', () => {
       context('single call to .resource', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.resource('users', 1)
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths attribute', () => {
@@ -220,9 +290,9 @@ describe('RailsRouteBuilder', () => {
       })
 
       context('chained calls to .resource', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.resource('users', 1).resource('blogPost', 2)
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths list', () => {
@@ -239,11 +309,16 @@ describe('RailsRouteBuilder', () => {
       expect(routeBuilder.chainedPaths).to.be.empty
     })
 
+    it('works with raw requests (ex: GET, POST, etc)', () => {
+      const route = routeBuilder.namespace('users')
+      expect(route.get('posts').path).to.eq('users/posts')
+    })
+
     context('namespace without params', () => {
       context('single call to .namespace', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.namespace('users')
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths attribute', () => {
@@ -253,9 +328,9 @@ describe('RailsRouteBuilder', () => {
       })
 
       context('chained calls to .namespace', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.namespace('users').namespace('blog_post')
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths list', () => {
@@ -267,9 +342,9 @@ describe('RailsRouteBuilder', () => {
 
     context('namespace with params', () => {
       context('single call to .namespace', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.namespace('users/:id', { id: 1 })
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths attribute', () => {
@@ -279,9 +354,9 @@ describe('RailsRouteBuilder', () => {
       })
 
       context('chained calls to .namespace', () => {
-        it('returns a new RailsRouteBuilder instance', () => {
+        it('returns a new RouteBuilder instance', () => {
           let returnedValue = routeBuilder.namespace('users/:id', { id: 1 }).namespace('blog_post/:id', { id: 2 })
-          expect(returnedValue).to.be.an.instanceOf(RailsRouteBuilder)
+          expect(returnedValue).to.be.an.instanceOf(RouteBuilder)
         })
 
         it('pushes the right data into the chainedPaths list', () => {


### PR DESCRIPTION
This was done to take advantage from the namespace features, that way if you do `api.namespace('users').get('profile')` it will work as expected.

Also with these changes, the `RailsRanger` class doesn't depend on the `PathBuilder` class anymore 🎉 

Fixes issue #28