### PR TITLE
Add documentation for request cancellation (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,16 @@ api.delete('users/:id', { id: 1, hidePassword: true })
 // => DELETE request to users/1&hide_password=true
 ```
 <br>
+
+## Request Cancellation
+Since rails-ranger is built on top of Axios, [request cancellation works the same way](https://github.com/axios/axios#cancellation).
+```javascript
+import api from 'api-client'
+
+import axios from 'axios';
+const CancelToken = axios.CancelToken;
+const source = CancelToken.source();
+
+const request = api.get('/users/:id', {id: 1}, {cancelToken: source.token})
+request.cancel = (optionalMessage) => source.cancel(optionalMessage);
+```


### PR DESCRIPTION
This PR adds documentation for request cancellation. It is added to the bottom of the README because the example uses the HTTP methods, and that is where the documentation for the HTTP methods are.